### PR TITLE
[FEATURE] Add an option to force the replacement of old translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line tool to translate JSON-based locale files using Google Translate.
 - 🎯 Handles nested JSON objects
 - 💪 Preserves original keys
 - 🎨 Colorful console output for better visibility
+- Keep old originale translations if alredy exist
 
 ## Installation
 
@@ -116,6 +117,9 @@ Output (`es.json`):
   }
 }
 ```
+
+### Force replacing
+This program translate only the new keys. If you want replacing all file content, add the --force-replace param to command line.
 
 ## Supported Languages
 

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,12 @@ async function main() {
     // Read source file
     const sourceData = await fs.readJson(options.source);
 
+    // Check if target file exists, if yes, parse it
+    let targetData = {};
+    if (options.output && fs.existsSync(options.output)) {
+      targetData = await fs.readJson(options.output);
+    }
+
     // Show translation info
     console.log(chalk.blue("\nTranslation Details:"));
     console.log(

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ async function main() {
     .option("-t, --to <lang>", "Target language code")
     .option("-o, --output <path>", "Output file path")
     .option("-i, --interactive", "Use interactive mode")
+    .option("--force-replace", "Force replace existing translations", false)
     .parse(process.argv);
 
   const options = program.opts();
@@ -133,14 +134,17 @@ async function main() {
       chalk.blue(`From: ${LANGUAGES[options.from]} (${options.from})`)
     );
     console.log(chalk.blue(`To: ${LANGUAGES[options.to]} (${options.to})`));
+    console.log(chalk.blue(`Replace existing content ${options.forceReplace}`));
     console.log(chalk.blue("Starting translation...\n"));
 
     // Translate the content
-    const translatedData = await translateObject(
-      sourceData,
-      options.from,
-      options.to
-    );
+    const translatedData = await translateObject({
+      obj: sourceData,
+      translated: targetData,
+      fromLang: options.from,
+      toLang: options.to,
+      replace: options.forceReplace
+    })
 
     // Determine output path
     const outputPath =

--- a/src/index.js
+++ b/src/index.js
@@ -56,25 +56,25 @@ async function selectLanguages() {
   return inquirer.prompt(questions);
 }
 
-async function translateObject(obj, fromLang, toLang) {
-  const translated = {};
-
+async function translateObject({obj, translated={}, fromLang, toLang, replace=false}) {
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === "object" && value !== null) {
-      translated[key] = await translateObject(value, fromLang, toLang);
+      translated[key] = await translateObject({obj: value, translated: translated[key] || {}, fromLang, toLang, replace});
     } else if (typeof value === "string") {
-      try {
-        const result = await translate(value, {
-          from: fromLang,
-          to: toLang,
-        });
-        translated[key] = result.text;
-        console.log(
-          chalk.green(`✓ [${fromLang} → ${toLang}] ${value} → ${result.text}`)
-        );
-      } catch (error) {
-        console.error(chalk.red(`✗ Failed to translate: ${value}`));
-        translated[key] = value;
+      if (!translated[key] || replace) {
+        try {
+          const result = await translate(value, {
+            from: fromLang,
+            to: toLang,
+          });
+          translated[key] = result.text;
+          console.log(
+              chalk.green(`✓ [${fromLang} → ${toLang}] ${value} → ${result.text}`)
+          );
+        } catch (error) {
+          console.error(chalk.red(`✗ Failed to translate: ${value}`));
+          translated[key] = value;
+        }
       }
     } else {
       translated[key] = value;


### PR DESCRIPTION
This pull request introduces enhancements to the translation functionality in `src/index.js`. The most notable changes include adding support for merging existing translations with new ones, introducing a `--force-replace` option to control overwriting behavior, and refactoring the `translateObject` function for better flexibility and clarity.

### Enhancements to translation functionality:

* **Support for merging existing translations**: The code now checks if a target file exists and parses it to include existing translations. This allows the translation process to merge new translations with previously translated content. (`[src/index.jsR125-R147](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R125-R147)`)

* **New `--force-replace` option**: Added a command-line option `--force-replace` to control whether existing translations should be overwritten. This option defaults to `false` and is displayed in the translation details. (`[[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R96)`, `[[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R125-R147)`)

### Refactoring for flexibility:

* **Refactored `translateObject` function**: Updated the function signature to accept a single object parameter with named properties (`obj`, `translated`, `fromLang`, `toLang`, `replace`). This improves readability and allows for more flexible handling of optional parameters. (`[src/index.jsL59-R64](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L59-R64)`)

* **Improved translation logic**: Enhanced the logic to only overwrite existing translations if the `replace` flag is set to `true`. This ensures that existing content is preserved unless explicitly specified. (`[src/index.jsR78](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R78)`)